### PR TITLE
Add a form for listener questions

### DIFF
--- a/components/ContactForm.js
+++ b/components/ContactForm.js
@@ -2,19 +2,29 @@ import React from 'react';
 import { useForm, ValidationError } from '@formspree/react';
 import styles from '../styles/ContactForm.module.css';
 
-function ContactForm() {
+export const formTypes = {
+  contact: 'contact',
+  question: 'question',
+}
+
+function ContactForm({
+  thanksMessage = 'Thank you for getting involved!',
+  messageLabel = 'Your Message:',
+  formType = formTypes.contact
+}) {
   const [state, handleSubmit] = useForm('xkneoezr');
   if (state.succeeded) {
-    return <p>Thank you for getting involved!</p>;
+    return <p>{thanksMessage}</p>;
   }
   return (
     <form onSubmit={handleSubmit} className={styles.contactForm}>
       <label htmlFor="email">Email Address:</label>
       <input id="email" type="email" name="email" />
       <ValidationError prefix="Email" field="email" errors={state.errors} />
-      <label htmlFor="message">Your Message:</label>
+      <label htmlFor="message">{messageLabel}</label>
       <textarea id="message" name="message" />
       <ValidationError prefix="Message" field="message" errors={state.errors} />
+      <input type="hidden" id="form-type" name="form-type" value={formType} />
       <button
         type="submit"
         disabled={state.submitting}
@@ -25,7 +35,5 @@ function ContactForm() {
     </form>
   );
 }
-function App() {
-  return <ContactForm />;
-}
-export default App;
+
+export default ContactForm;

--- a/components/Hero.js
+++ b/components/Hero.js
@@ -31,7 +31,7 @@ const Hero = ({ isShort = false }) => {
                   <div>
                     <h3>Joe Boyle</h3>
                     <p>
-                      Frontend Platform Engineer at Wayfair, former animator
+                      Frontend Platform Engineer, former animator
                     </p>
                   </div>
                 </div>

--- a/components/Hero.js
+++ b/components/Hero.js
@@ -66,6 +66,11 @@ const Hero = ({ isShort = false }) => {
             <a className={styles.link}>Make a Suggestion</a>
           </Link>
         </div>
+        <div className={styles.linkWrapper}>
+          <Link href="/questions">
+            <a className={styles.link}>Ask a Question</a>
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/pages/questions.js
+++ b/pages/questions.js
@@ -1,0 +1,26 @@
+import styles from '../styles/SuggestionsPage.module.css';
+import LineBreak from '../components/LineBreak';
+import LogoBanner from '../components/LogoBanner';
+import ContactForm, { formTypes } from '../components/ContactForm';
+
+const Questions = () => {
+  return (
+    <>
+      <div className={styles.suggestionsCard}>
+        <LogoBanner />
+      </div>
+      <div className={styles.suggestionsCard}>
+        <h2>Ask a Question</h2>
+        <p>Have a question for us? Post it here and we might answer it on a future show!</p>
+      </div>
+      <div className={styles.suggestionsWrapper}>
+        <div className={styles.suggestionsCard}>
+          <LineBreak content="Ask us a Question" />
+          <ContactForm formType={formTypes.question} thanksMessage="Thank you for your question!" messageLabel="Your Question:" />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Questions;

--- a/pages/questions.js
+++ b/pages/questions.js
@@ -16,7 +16,11 @@ const Questions = () => {
       <div className={styles.suggestionsWrapper}>
         <div className={styles.suggestionsCard}>
           <LineBreak content="Ask us a Question" />
-          <ContactForm formType={formTypes.question} thanksMessage="Thank you for your question!" messageLabel="Your Question:" />
+          <ContactForm
+            formType={formTypes.question}
+            thanksMessage="Thank you for your question!"
+            messageLabel="Your Question (include a name, we won't read your email address on the show):"
+          />
         </div>
       </div>
     </>


### PR DESCRIPTION
## Why

So listeners can ask questions and we can maybe someday have enough to turn them into a mailbag episode.

## Details

I added some props to the Contact form and gave it a `formType` so we can filter emails based on `form-type: question`. Confirmed it adds that field to the email body 👍 

Resolves #6 