### PR TITLE
Audio player styling

### DIFF
--- a/app/episodes/[slug]/page.js
+++ b/app/episodes/[slug]/page.js
@@ -34,7 +34,7 @@ async function EpisodePage({ params: { slug } }) {
       <div className={styles.episodeDetailsWrapper}>
         <div className={styles.titleWrapper}>
           <h3 className={styles.episodeTitle}>{episodeDetails.title}</h3>
-          <audio controls>
+          <audio className={styles.episodePlayer} controls>
             <source src={src} type="audio/mpeg" />
             Your browser does not support the audio element.
           </audio>

--- a/styles/EpisodePage.module.css
+++ b/styles/EpisodePage.module.css
@@ -21,11 +21,14 @@
 }
 
 .episodePlayer {
-  text-align: center;
-  padding: 8px 16px 24px 16px;
   border-radius: 4px;
-  background-color: rgba(16, 66, 133, 0.2);
   box-shadow: var(--base-box-shadow);
+  border: 5px solid var(--color-base-blue);
+  background-color: var(--color-base-white);
+}
+
+.episodePlayer::-webkit-media-controls-panel {
+  background-color: var(--color-base-white);
 }
 
 .episodeDetails {
@@ -66,5 +69,12 @@
 
   .episodePageCard {
     margin: 0;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .episodePlayer,
+  .episodePlayer::-webkit-media-controls-panel {
+    background-color: var(--color-base-blue);
   }
 }


### PR DESCRIPTION
## What problem does this solve?

The low-contrast black-on-dark-blue audio player was bugging me.

## Details

The audio player isn't very customizable unless we want to go full custom controls at some point. Text/controls are white when the system is in dark mode, and black when in light mode, so I went with white background for `prefers-color-scheme: light` and dark blue for `prefers-color-scheme: dark`.

Also, the `.episodePlayer` class wasn't being used, so I removed some unused styling (but kept the rounded corners)

## Screenshots

Here's what it looks like on Chrome:

**Prefers light:**

<img width="420" alt="image" src="https://github.com/runtime-rundown/podcast-site/assets/8823810/38ccb4b6-8833-4231-a706-ec24f9832f74">

**Prefers dark:**

<img width="411" alt="image" src="https://github.com/runtime-rundown/podcast-site/assets/8823810/57156d90-c722-4189-8db0-21d49c9a6f2c">

Doesn't look terrible on Firefox, although the background is a little bit different from the native player (and there doesn't appear to be a way to style the player background on FF)

<img width="403" alt="image" src="https://github.com/runtime-rundown/podcast-site/assets/8823810/90c2d7ca-14e8-462b-88ce-6ce0b8a1872b">
