### PR TITLE
Revert "Audio player styling"

### DIFF
--- a/app/episodes/[slug]/page.js
+++ b/app/episodes/[slug]/page.js
@@ -34,7 +34,7 @@ async function EpisodePage({ params: { slug } }) {
       <div className={styles.episodeDetailsWrapper}>
         <div className={styles.titleWrapper}>
           <h3 className={styles.episodeTitle}>{episodeDetails.title}</h3>
-          <audio className={styles.episodePlayer} controls>
+          <audio controls>
             <source src={src} type="audio/mpeg" />
             Your browser does not support the audio element.
           </audio>

--- a/styles/EpisodePage.module.css
+++ b/styles/EpisodePage.module.css
@@ -21,14 +21,11 @@
 }
 
 .episodePlayer {
+  text-align: center;
+  padding: 8px 16px 24px 16px;
   border-radius: 4px;
+  background-color: rgba(16, 66, 133, 0.2);
   box-shadow: var(--base-box-shadow);
-  border: 5px solid var(--color-base-blue);
-  background-color: var(--color-base-white);
-}
-
-.episodePlayer::-webkit-media-controls-panel {
-  background-color: var(--color-base-white);
 }
 
 .episodeDetails {
@@ -69,12 +66,5 @@
 
   .episodePageCard {
     margin: 0;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .episodePlayer,
-  .episodePlayer::-webkit-media-controls-panel {
-    background-color: var(--color-base-blue);
   }
 }


### PR DESCRIPTION
## Description

CSS looks bad on mobile, I'll investigate later.

This reverts commit 87905e6e5569cb7dd5241a02f923def1eb249bc5.

<img src="https://github.com/runtime-rundown/podcast-site/assets/8823810/580c1705-1839-4ce2-b8a8-f7f38cc25469" width="400" />
