### PR TITLE
Highlight multiple search terms

### DIFF
--- a/utils/__tests__/search.test.js
+++ b/utils/__tests__/search.test.js
@@ -3,7 +3,7 @@ import {
   createEpisodeMap,
   createTrie,
   mapWordsToEpisodeTitles,
-  splitOnTerm,
+  splitOnTerms,
   processEpisodes,
   getMatchingWords,
   searchForTitles,
@@ -139,17 +139,17 @@ describe('Search utils', () => {
     });
   });
 
-  describe('splitOnTerm', () => {
+  describe('splitOnTerms', () => {
     const LONG_CONTENT =
       'Some much longer, more verbose content that will certainly, definitely, absolutely, clearly, one hundred percent overflow max length';
 
     it('splits content into before, term, after', () => {
       const content = 'Some content';
-      expect(splitOnTerm(content, 'con')).toEqual(['Some ', 'con', 'tent']);
+      expect(splitOnTerms(content, 'con')).toEqual(['Some ', 'con', 'tent']);
     });
 
     it('truncates beginning', () => {
-      expect(splitOnTerm(LONG_CONTENT, 'max')).toEqual([
+      expect(splitOnTerms(LONG_CONTENT, 'max')).toEqual([
         '...absolutely, clearly, one hundred percent overflow ',
         'max',
         ' length',
@@ -157,15 +157,29 @@ describe('Search utils', () => {
     });
 
     it('truncates end', () => {
-      expect(splitOnTerm(LONG_CONTENT, 'much')).toEqual([
+      expect(splitOnTerms(LONG_CONTENT, 'much')).toEqual([
         'Some ',
         'much',
         ' longer, more verbose content that will certainly,...',
       ]);
     });
 
+    it('splits multiple times on the same word', () => {
+      expect(splitOnTerms(LONG_CONTENT, 'ly')).toEqual([
+        '...uch longer, more verbose content that will certain',
+        'ly',
+        ', definite',
+        'ly',
+        ', absolute',
+        'ly',
+        ', clear',
+        'ly',
+        ', one hundred percent overflow max length',
+      ]);
+    });
+
     it('truncates both sides', () => {
-      expect(splitOnTerm(LONG_CONTENT, 'definitely')).toEqual([
+      expect(splitOnTerms(LONG_CONTENT, 'definitely')).toEqual([
         '...longer, more verbose content that will certainly, ',
         'definitely',
         ', absolutely, clearly, one hundred percent overflo...',
@@ -173,15 +187,11 @@ describe('Search utils', () => {
     });
 
     it('handles empty term', () => {
-      expect(splitOnTerm(LONG_CONTENT, undefined)).toEqual([
-        '',
-        '',
-        'Some much longer, more verbose content that will c...',
-      ]);
+      expect(splitOnTerms(LONG_CONTENT, undefined)).toEqual([LONG_CONTENT]);
     });
 
     it('ignores whitespace on either side', () => {
-      expect(splitOnTerm('Some content', ' con ')).toEqual([
+      expect(splitOnTerms('Some content', ' con ')).toEqual([
         'Some ',
         'con',
         'tent',
@@ -189,20 +199,22 @@ describe('Search utils', () => {
     });
 
     it('handles empty content', () => {
-      expect(splitOnTerm(undefined, 'max')).toEqual(['']);
+      expect(splitOnTerms(undefined, 'max')).toEqual(['']);
     });
 
     it('highlights match in multiple terms', () => {
-      expect(splitOnTerm(LONG_CONTENT, 'longer verbose')).toEqual([
+      expect(splitOnTerms(LONG_CONTENT, 'longer verbose')).toEqual([
         'Some much ',
         'longer',
-        ', more verbose content that will certainly, defini...',
+        ', more ',
+        'verbose',
+        ' content that will certainly, definitely, absolute...',
       ]);
     });
 
     it('highlights first matching term of multiple terms', () => {
       // verbose is later in the sentence but it's the first match
-      expect(splitOnTerm(LONG_CONTENT, 'foo verbose')).toEqual([
+      expect(splitOnTerms(LONG_CONTENT, 'foo verbose')).toEqual([
         'Some much longer, more ',
         'verbose',
         ' content that will certainly, definitely, absolute...',

--- a/utils/search.ts
+++ b/utils/search.ts
@@ -91,7 +91,9 @@ function truncate(content: string[]): string[] {
 
   const halfMax = MAX_CONTENT_LENGTH / 2;
 
-  const [start, mid, end] = content;
+  const start = content.at(0);
+  const mid = content.slice(1, -1);
+  const end = content.at(-1);
 
   // TODO: Better way to do this than using halfMax
   const truncatedStart =
@@ -102,32 +104,21 @@ function truncate(content: string[]): string[] {
   const truncatedEnd =
     end.length < halfMax ? end : end.slice(0, halfMax) + '...';
 
-  return [truncatedStart, mid, truncatedEnd];
+  return [truncatedStart, ...mid, truncatedEnd];
 }
 
 /**
- * Split content into before input, input, and after input
+ * Split content into matching and non-matching parts
  */
-export function splitOnTerm(content = '', searchTerm = ''): string[] {
-  // TODO: Currently only highlights the first matching term, but would be nice
-  // to highlight all matching terms
+export function splitOnTerms(content = '', searchTerm = ''): string[] {
   const terms = searchTerm.trim().split(' ');
   const re = new RegExp(`(${terms.join('|')})`, 'gi');
-  const match = content.match(re);
 
-  if (!match) {
+  if (searchTerm === '') {
     return [content];
   }
 
-  const [firstMatch] = match;
-
-  const lineIndex = content.toLowerCase().indexOf(firstMatch.toLowerCase());
-
-  return truncate([
-    content.slice(0, lineIndex),
-    content.slice(lineIndex, lineIndex + firstMatch.length),
-    content.slice(lineIndex + firstMatch.length),
-  ]);
+  return truncate(content.split(re));
 }
 
 /**

--- a/utils/search.ts
+++ b/utils/search.ts
@@ -111,12 +111,12 @@ function truncate(content: string[]): string[] {
  * Split content into matching and non-matching parts
  */
 export function splitOnTerms(content = '', searchTerm = ''): string[] {
-  const terms = searchTerm.trim().split(' ');
-  const re = new RegExp(`(${terms.join('|')})`, 'gi');
-
   if (searchTerm === '') {
     return [content];
   }
+
+  const terms = searchTerm.trim().split(' ');
+  const re = new RegExp(`(${terms.join('|')})`, 'gi');
 
   return truncate(content.split(re));
 }

--- a/utils/search.ts
+++ b/utils/search.ts
@@ -118,6 +118,9 @@ export function splitOnTerms(content = '', searchTerm = ''): string[] {
   const terms = searchTerm.trim().split(' ');
   const re = new RegExp(`(${terms.join('|')})`, 'gi');
 
+  // Splitting on a RegExp that includes capturing groups will include the
+  // matched terms in the result
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split#splitting_with_a_regexp_to_include_parts_of_the_separator_in_the_result
   return truncate(content.split(re));
 }
 


### PR DESCRIPTION
## What problem does this solve?

Search only highlights the first instance of the first matching term. This PR adds highlighting to all instances of all matching terms

## Screenshots

Before | After
-- | --
<img alt="before" src="https://github.com/runtime-rundown/podcast-site/assets/8823810/21a0837f-ab86-454c-97e2-66a3cb21eb91"> | <img alt="after" src="https://github.com/runtime-rundown/podcast-site/assets/8823810/fd1f0ec7-111a-49e7-a5a0-e21136cf27f7">

## Details

Basically just handles the entire RegExp match instead of only sandwiching the first term between the beginning and end of the content.

Conveniently enough, splitting on matching terms results in an array where the even entries are the ones we want highlighted and the odd ones aren't:

```js
splitOnTerms('Here is an example', 'is an');
// ['Here ', 'is', ' ', 'an', ' example']
```

I used this in `Search.ts` but made a note that this is a hacky solution that probably fails under some edge cases. We can probably follow up with a refactor to convert the string into a `Hilight` object, something like this would give us a more explicit way to determine whether something should be highlighted or not:

```ts
type Hilight = { text: string, isMatch: boolean };
```
