### PR TITLE
Better search ordering

### DIFF
--- a/__fixtures__/episodes.js
+++ b/__fixtures__/episodes.js
@@ -1,7 +1,9 @@
 export const episodesFixture = [
   { title: 'React', contentSnippet: 'An episode about React\nalways React' },
   { title: 'Testing', contentSnippet: 'An episode about testing' },
+  { title: 'Testing Two', contentSnippet: 'Another episode about testing' },
   { title: 'Other', contentSnippet: 'Another random episode' },
+  { title: 'Another', contentSnippet: 'Another other random episode' },
   { title: 'Career', contentSnippet: 'Career episode' },
 ];
 
@@ -11,6 +13,14 @@ export const episodeMapFixture = {
     contentSnippet: 'An episode about React\nalways React',
   },
   Testing: { title: 'Testing', contentSnippet: 'An episode about testing' },
+  'Testing Two': {
+    title: 'Testing Two',
+    contentSnippet: 'Another episode about testing',
+  },
+  Another: {
+    title: 'Another',
+    contentSnippet: 'Another other random episode',
+  },
   Other: {
     title: 'Other',
     contentSnippet: 'Another random episode',
@@ -19,16 +29,24 @@ export const episodeMapFixture = {
 };
 
 export const searchTermsFixture = {
-  about: new Set(['React', 'Testing']),
+  about: new Set(['React', 'Testing', 'Testing Two']),
   always: new Set(['React']),
   an: new Set(['React', 'Testing']),
   career: new Set(['Career']),
-  other: new Set(['Other']),
-  another: new Set(['Other']),
-  episode: new Set(['React', 'Testing', 'Other', 'Career']),
+  other: new Set(['Other', 'Another']),
+  another: new Set(['Testing Two', 'Other', 'Another']),
+  episode: new Set([
+    'React',
+    'Testing',
+    'Testing Two',
+    'Other',
+    'Career',
+    'Another',
+  ]),
   react: new Set(['React']),
-  random: new Set(['Other']),
-  testing: new Set(['Testing']),
+  random: new Set(['Other', 'Another']),
+  two: new Set(['Testing Two']),
+  testing: new Set(['Testing', 'Testing Two']),
 };
 
 export const trieFixture = {
@@ -183,7 +201,13 @@ export const trieFixture = {
       },
       words: ['testing'],
     },
-    words: ['testing'],
+    w: {
+      o: {
+        words: ['two'],
+      },
+      words: ['two'],
+    },
+    words: ['testing', 'two'],
   },
   words: [],
 };

--- a/__fixtures__/sorting.js
+++ b/__fixtures__/sorting.js
@@ -1,0 +1,183 @@
+export const sortingFixture = [
+  { title: 'Title with foo', contentSnippet: 'An episode with foo and bar' },
+  {
+    title: 'Title with bar',
+    contentSnippet: 'An episode with bar and foo',
+  },
+  {
+    title: 'Title with foo and bar',
+    contentSnippet: 'An episode with both foo and bar',
+  },
+  {
+    title: 'Title with baz',
+    contentSnippet: 'Another episode with both foo and bar and baz',
+  },
+];
+
+export const sortingMapFixture = {
+  'Title with foo': {
+    title: 'Title with foo',
+    contentSnippet: 'An episode with foo and bar',
+  },
+  'Title with bar': {
+    title: 'Title with bar',
+    contentSnippet: 'An episode with bar and foo',
+  },
+  'Title with foo and bar': {
+    title: 'Title with foo and bar',
+    contentSnippet: 'An episode with both foo and bar',
+  },
+  'Title with baz': {
+    title: 'Title with baz',
+    contentSnippet: 'Another episode with both foo and bar and baz',
+  },
+};
+
+export const sortingSearchTermsFixture = {
+  an: new Set(['Title with foo', 'Title with bar', 'Title with foo and bar']),
+  and: new Set([
+    'Title with foo',
+    'Title with bar',
+    'Title with foo and bar',
+    'Title with baz',
+  ]),
+  another: new Set(['Title with baz']),
+  bar: new Set([
+    'Title with foo',
+    'Title with bar',
+    'Title with foo and bar',
+    'Title with baz',
+  ]),
+  baz: new Set(['Title with baz']),
+  both: new Set(['Title with foo and bar', 'Title with baz']),
+  episode: new Set([
+    'Title with foo',
+    'Title with bar',
+    'Title with foo and bar',
+    'Title with baz',
+  ]),
+  foo: new Set([
+    'Title with foo',
+    'Title with bar',
+    'Title with foo and bar',
+    'Title with baz',
+  ]),
+  title: new Set([
+    'Title with foo',
+    'Title with bar',
+    'Title with foo and bar',
+    'Title with baz',
+  ]),
+  with: new Set([
+    'Title with foo',
+    'Title with bar',
+    'Title with foo and bar',
+    'Title with baz',
+  ]),
+};
+
+export const sortingTrieFixture = {
+  a: {
+    n: {
+      d: {
+        words: ['and'],
+      },
+      o: {
+        t: {
+          h: {
+            e: {
+              r: {
+                words: ['another'],
+              },
+              words: ['another'],
+            },
+            words: ['another'],
+          },
+          words: ['another'],
+        },
+        words: ['another'],
+      },
+      words: ['an', 'and', 'another'],
+    },
+    words: ['an', 'and', 'another'],
+  },
+  b: {
+    a: {
+      r: {
+        words: ['bar'],
+      },
+      words: ['bar', 'baz'],
+      z: {
+        words: ['baz'],
+      },
+    },
+    o: {
+      t: {
+        h: {
+          words: ['both'],
+        },
+        words: ['both'],
+      },
+      words: ['both'],
+    },
+    words: ['bar', 'baz', 'both'],
+  },
+  e: {
+    p: {
+      i: {
+        s: {
+          o: {
+            d: {
+              e: {
+                words: ['episode'],
+              },
+              words: ['episode'],
+            },
+            words: ['episode'],
+          },
+          words: ['episode'],
+        },
+        words: ['episode'],
+      },
+      words: ['episode'],
+    },
+    words: ['episode'],
+  },
+  f: {
+    o: {
+      o: {
+        words: ['foo'],
+      },
+      words: ['foo'],
+    },
+    words: ['foo'],
+  },
+  t: {
+    i: {
+      t: {
+        l: {
+          e: {
+            words: ['title'],
+          },
+          words: ['title'],
+        },
+        words: ['title'],
+      },
+      words: ['title'],
+    },
+    words: ['title'],
+  },
+  w: {
+    i: {
+      t: {
+        h: {
+          words: ['with'],
+        },
+        words: ['with'],
+      },
+      words: ['with'],
+    },
+    words: ['with'],
+  },
+  words: [],
+};

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -95,8 +95,6 @@ function Search({ searchTerms, trie, episodeMap }: SearchProps) {
           onBlur={handleSearchBlur}
         >
           <ul className={styles.searchResults}>
-            {/* TODO: Sort with the best matches first, e.g. "get the bas"
-            should put "Get the Basics Right" first */}
             {titles.map(title => {
               const contentLines =
                 episodeMap[title].contentSnippet.split(/\. |\n/);

--- a/components/__tests__/Search.test.jsx
+++ b/components/__tests__/Search.test.jsx
@@ -67,6 +67,33 @@ describe('Search', () => {
     );
   });
 
+  it('sorts best matches at the top', async () => {
+    render(
+      <Search
+        trie={trieFixture}
+        episodeMap={episodeMapFixture}
+        searchTerms={searchTermsFixture}
+      />,
+    );
+    expect(screen.queryByRole('list')).not.toBeTruthy();
+    fireEvent.focus(screen.getByLabelText(/search/i));
+    // TODO: Why does this not work?
+    fireEvent.change(screen.getByLabelText(/search/i), {
+      target: { value: 'another' },
+    });
+    expect(screen.getByRole('list')).toBeTruthy();
+    expect(screen.getAllByRole('listitem').length).toBe(3);
+    expect(screen.getAllByRole('listitem')[0].textContent).toBe(
+      'AnotherAnother other random episode',
+    );
+    expect(screen.getAllByRole('listitem')[1].textContent).toBe(
+      'Testing TwoAnother episode about testing',
+    );
+    expect(screen.getAllByRole('listitem')[2].textContent).toBe(
+      'OtherAnother random episode',
+    );
+  });
+
   it('matches multiple words', async () => {
     render(
       <Search
@@ -82,10 +109,12 @@ describe('Search', () => {
     });
     expect(screen.getByRole('list')).toBeTruthy();
     const listItems = screen.getAllByRole('listitem');
-    expect(listItems.length).toBe(3);
+    expect(listItems.length).toBe(5);
 
     expect(listItems[0].textContent).toMatch('An episode about React');
     expect(listItems[1].textContent).toMatch('An episode about testing');
-    expect(listItems[2].textContent).toMatch('Another random episode');
+    expect(listItems[2].textContent).toMatch('Another episode about testing');
+    expect(listItems[3].textContent).toMatch('Another random episode');
+    expect(listItems[4].textContent).toMatch('Another other random episode');
   });
 });

--- a/utils/__tests__/search.test.js
+++ b/utils/__tests__/search.test.js
@@ -143,6 +143,8 @@ describe('Search utils', () => {
 
       describe('Sorting', () => {
         it('sorting fixtures are correct', () => {
+          // This test is just to ensure the data in the fixtures are
+          // internally consistent
           const episodeMap = createEpisodeMap(sortingFixture);
           expect(episodeMap).toEqual(sortingMapFixture);
           const sortingTerms = mapWordsToEpisodeTitles(sortingFixture);

--- a/utils/__tests__/search.test.js
+++ b/utils/__tests__/search.test.js
@@ -127,6 +127,13 @@ describe('Search utils', () => {
           searchForTitles({ trie, searchTerms, searchTerm: 'xyz' }),
         ).toEqual([]);
       });
+
+      it('orders exact matches first', () => {
+        const trie = createTrie(searchTerms);
+        expect(
+          searchForTitles({ trie, searchTerms, searchTerm: 'another' }),
+        ).toEqual(['Another', 'Testing Two', 'Other']);
+      });
     });
 
     describe('multiple search terms', () => {

--- a/utils/__tests__/search.test.js
+++ b/utils/__tests__/search.test.js
@@ -104,7 +104,14 @@ describe('Search utils', () => {
         const trie = createTrie(searchTerms);
         expect(
           searchForTitles({ trie, searchTerms, searchTerm: 'epis' }),
-        ).toEqual(['React', 'Testing', 'Other', 'Career']);
+        ).toEqual([
+          'React',
+          'Testing',
+          'Testing Two',
+          'Other',
+          'Career',
+          'Another',
+        ]);
       });
 
       it('trims whitespace around search', () => {
@@ -127,7 +134,7 @@ describe('Search utils', () => {
         const trie = createTrie(searchTerms);
         expect(
           searchForTitles({ trie, searchTerms, searchTerm: 'epIsOde an' }),
-        ).toEqual(['React', 'Testing', 'Other']);
+        ).toEqual(['React', 'Testing', 'Testing Two', 'Other', 'Another']);
       });
 
       it('returns empty array if one term doesnt match', () => {

--- a/utils/__tests__/search.test.js
+++ b/utils/__tests__/search.test.js
@@ -3,7 +3,7 @@ import {
   createEpisodeMap,
   createTrie,
   mapWordsToEpisodeTitles,
-  splitOnTerm,
+  splitOnTerms,
   processEpisodes,
   getMatchingWords,
   searchForTitles,
@@ -139,17 +139,17 @@ describe('Search utils', () => {
     });
   });
 
-  describe('splitOnTerm', () => {
+  describe('splitOnTerms', () => {
     const LONG_CONTENT =
       'Some much longer, more verbose content that will certainly, definitely, absolutely, clearly, one hundred percent overflow max length';
 
     it('splits content into before, term, after', () => {
       const content = 'Some content';
-      expect(splitOnTerm(content, 'con')).toEqual(['Some ', 'con', 'tent']);
+      expect(splitOnTerms(content, 'con')).toEqual(['Some ', 'con', 'tent']);
     });
 
     it('truncates beginning', () => {
-      expect(splitOnTerm(LONG_CONTENT, 'max')).toEqual([
+      expect(splitOnTerms(LONG_CONTENT, 'max')).toEqual([
         '...absolutely, clearly, one hundred percent overflow ',
         'max',
         ' length',
@@ -157,15 +157,29 @@ describe('Search utils', () => {
     });
 
     it('truncates end', () => {
-      expect(splitOnTerm(LONG_CONTENT, 'much')).toEqual([
+      expect(splitOnTerms(LONG_CONTENT, 'much')).toEqual([
         'Some ',
         'much',
         ' longer, more verbose content that will certainly,...',
       ]);
     });
 
+    it('splits multiple times on the same word', () => {
+      expect(splitOnTerms(LONG_CONTENT, 'ly')).toEqual([
+        '...uch longer, more verbose content that will certain',
+        'ly',
+        ', definite',
+        'ly',
+        ', absolute',
+        'ly',
+        ', clear',
+        'ly',
+        ', one hundred percent overflow max length',
+      ]);
+    });
+
     it('truncates both sides', () => {
-      expect(splitOnTerm(LONG_CONTENT, 'definitely')).toEqual([
+      expect(splitOnTerms(LONG_CONTENT, 'definitely')).toEqual([
         '...longer, more verbose content that will certainly, ',
         'definitely',
         ', absolutely, clearly, one hundred percent overflo...',
@@ -173,15 +187,11 @@ describe('Search utils', () => {
     });
 
     it('handles empty term', () => {
-      expect(splitOnTerm(LONG_CONTENT, undefined)).toEqual([
-        '',
-        '',
-        'Some much longer, more verbose content that will c...',
-      ]);
+      expect(splitOnTerms(LONG_CONTENT, undefined)).toEqual([LONG_CONTENT]);
     });
 
     it('ignores whitespace on either side', () => {
-      expect(splitOnTerm('Some content', ' con ')).toEqual([
+      expect(splitOnTerms('Some content', ' con ')).toEqual([
         'Some ',
         'con',
         'tent',
@@ -189,20 +199,22 @@ describe('Search utils', () => {
     });
 
     it('handles empty content', () => {
-      expect(splitOnTerm(undefined, 'max')).toEqual(['']);
+      expect(splitOnTerms(undefined, 'max')).toEqual(['']);
     });
 
     it('highlights match in multiple terms', () => {
-      expect(splitOnTerm(LONG_CONTENT, 'longer verbose')).toEqual([
+      expect(splitOnTerms(LONG_CONTENT, 'longer verbose')).toEqual([
         'Some much ',
         'longer',
-        ', more verbose content that will certainly, defini...',
+        ', more ',
+        'verbose',
+        ' content that will certainly, definitely, absolute...',
       ]);
     });
 
     it('highlights first matching term of multiple terms', () => {
       // verbose is later in the sentence but it's the first match
-      expect(splitOnTerm(LONG_CONTENT, 'foo verbose')).toEqual([
+      expect(splitOnTerms(LONG_CONTENT, 'foo verbose')).toEqual([
         'Some much longer, more ',
         'verbose',
         ' content that will certainly, definitely, absolute...',

--- a/utils/__tests__/search.test.js
+++ b/utils/__tests__/search.test.js
@@ -14,6 +14,12 @@ import {
   searchTermsFixture as searchTerms,
   trieFixture,
 } from '../../__fixtures__/episodes';
+import {
+  sortingMapFixture,
+  sortingFixture,
+  sortingSearchTermsFixture,
+  sortingTrieFixture,
+} from '../../__fixtures__/sorting';
 
 describe('Search utils', () => {
   it('creates a trie', () => {
@@ -30,8 +36,8 @@ describe('Search utils', () => {
 
   describe('mapWordsToEpisodeTitles', () => {
     it('creates a map of search terms to episode titles', () => {
-      const searchTerms = mapWordsToEpisodeTitles(episodesFixture);
-      expect(searchTerms).toEqual(searchTerms);
+      const expectedSearchTerms = mapWordsToEpisodeTitles(episodesFixture);
+      expect(searchTerms).toEqual(expectedSearchTerms);
     });
 
     it('search terms are lowercased', () => {
@@ -133,6 +139,32 @@ describe('Search utils', () => {
         expect(
           searchForTitles({ trie, searchTerms, searchTerm: 'another' }),
         ).toEqual(['Another', 'Testing Two', 'Other']);
+      });
+
+      describe('Sorting', () => {
+        it('sorting fixtures are correct', () => {
+          const episodeMap = createEpisodeMap(sortingFixture);
+          expect(episodeMap).toEqual(sortingMapFixture);
+          const sortingTerms = mapWordsToEpisodeTitles(sortingFixture);
+          expect(sortingTerms).toEqual(sortingSearchTermsFixture);
+          const trie = createTrie(sortingTerms);
+          expect(trie).toEqual(sortingTrieFixture);
+        });
+
+        it('orders match in title before match in content', () => {
+          expect(
+            searchForTitles({
+              trie: sortingTrieFixture,
+              searchTerms: sortingSearchTermsFixture,
+              searchTerm: 'FOO BAR',
+            }),
+          ).toEqual([
+            'Title with foo and bar',
+            'Title with foo',
+            'Title with bar',
+            'Title with baz',
+          ]);
+        });
       });
     });
 

--- a/utils/search.ts
+++ b/utils/search.ts
@@ -91,7 +91,9 @@ function truncate(content: string[]): string[] {
 
   const halfMax = MAX_CONTENT_LENGTH / 2;
 
-  const [start, mid, end] = content;
+  const start = content.at(0);
+  const mid = content.slice(1, -1);
+  const end = content.at(-1);
 
   // TODO: Better way to do this than using halfMax
   const truncatedStart =
@@ -102,32 +104,21 @@ function truncate(content: string[]): string[] {
   const truncatedEnd =
     end.length < halfMax ? end : end.slice(0, halfMax) + '...';
 
-  return [truncatedStart, mid, truncatedEnd];
+  return [truncatedStart, ...mid, truncatedEnd];
 }
 
 /**
- * Split content into before input, input, and after input
+ * Split content into matching and non-matching parts
  */
-export function splitOnTerm(content = '', searchTerm = ''): string[] {
-  // TODO: Currently only highlights the first matching term, but would be nice
-  // to highlight all matching terms
+export function splitOnTerms(content = '', searchTerm = ''): string[] {
   const terms = searchTerm.trim().split(' ');
   const re = new RegExp(`(${terms.join('|')})`, 'gi');
-  const match = content.match(re);
 
-  if (!match) {
+  if (searchTerm === '') {
     return [content];
   }
 
-  const [firstMatch] = match;
-
-  const lineIndex = content.toLowerCase().indexOf(firstMatch.toLowerCase());
-
-  return truncate([
-    content.slice(0, lineIndex),
-    content.slice(lineIndex, lineIndex + firstMatch.length),
-    content.slice(lineIndex + firstMatch.length),
-  ]);
+  return truncate(content.split(re));
 }
 
 /**

--- a/utils/search.ts
+++ b/utils/search.ts
@@ -111,12 +111,12 @@ function truncate(content: string[]): string[] {
  * Split content into matching and non-matching parts
  */
 export function splitOnTerms(content = '', searchTerm = ''): string[] {
-  const terms = searchTerm.trim().split(' ');
-  const re = new RegExp(`(${terms.join('|')})`, 'gi');
-
   if (searchTerm === '') {
     return [content];
   }
+
+  const terms = searchTerm.trim().split(' ');
+  const re = new RegExp(`(${terms.join('|')})`, 'gi');
 
   return truncate(content.split(re));
 }

--- a/utils/search.ts
+++ b/utils/search.ts
@@ -76,12 +76,14 @@ export function searchForTitles({
   }, new Set<string>());
 
   // Sort by how well the title matches the search term
-  return [...titlesMatchingAllWords].sort((a, b) => {
+  return [...titlesMatchingAllWords].sort((aTitle, bTitle) => {
     const lowerSearchTerm = searchTerm.toLowerCase();
-    const lowerA = a.toLowerCase();
-    const lowerB = b.toLowerCase();
+    const lowerA = aTitle.toLowerCase();
+    const lowerB = bTitle.toLowerCase();
 
     // TODO: Optimize this sorting
+
+    // Sort titles that start with the search term first
     if (lowerA.includes(lowerSearchTerm) && !lowerB.includes(lowerSearchTerm)) {
       return -1;
     }
@@ -89,7 +91,8 @@ export function searchForTitles({
       return 1;
     }
 
-    // Sort greater number of matching words first
+    // Sort greater number of matching words in the title before matching words
+    // in the content
     const aWords = lowerA.split(' ');
     const bWords = lowerB.split(' ');
 

--- a/utils/search.ts
+++ b/utils/search.ts
@@ -50,7 +50,7 @@ export function searchForTitles({
   searchTerm: string;
 }): string[] {
   // TODO: Memoize each word's results
-  const searchTermWords = searchTerm.trim().split(' ');
+  const searchTermWords = searchTerm.toLowerCase().trim().split(' ');
 
   const titlesMatchingAllWords = searchTermWords.reduce((acc, word) => {
     const matches = getMatchingWords(trie, word);
@@ -81,13 +81,28 @@ export function searchForTitles({
     const lowerA = a.toLowerCase();
     const lowerB = b.toLowerCase();
 
-    // TODO: Improve this, could do a better fuzzy match
+    // TODO: Optimize this sorting
     if (lowerA.includes(lowerSearchTerm) && !lowerB.includes(lowerSearchTerm)) {
       return -1;
     }
     if (lowerB.includes(lowerSearchTerm) && !lowerA.includes(lowerSearchTerm)) {
       return 1;
     }
+
+    // Sort greater number of matching words first
+    const aWords = lowerA.split(' ');
+    const bWords = lowerB.split(' ');
+
+    const aMatches = aWords.filter(word => searchTermWords.includes(word));
+    const bMatches = bWords.filter(word => searchTermWords.includes(word));
+
+    if (aMatches.length > bMatches.length) {
+      return -1;
+    }
+    if (bMatches.length > aMatches.length) {
+      return 1;
+    }
+
     return 0;
   });
 }

--- a/utils/search.ts
+++ b/utils/search.ts
@@ -65,6 +65,8 @@ export function searchForTitles({
       return new Set<string>(titles);
     }
 
+    // TODO: Revisit this - why am I adding to result and returning result
+    // instead of returning acc?
     const result = new Set<string>();
 
     titles.forEach(title => {
@@ -76,7 +78,21 @@ export function searchForTitles({
     return result;
   }, new Set<string>());
 
-  return [...titlesMatchingAllWords];
+  // Sort by how well the title matches the search term
+  return [...titlesMatchingAllWords].sort((a, b) => {
+    const lowerSearchTerm = searchTerm.toLowerCase();
+    const lowerA = a.toLowerCase();
+    const lowerB = b.toLowerCase();
+
+    // TODO: Improve this, could do a better fuzzy match
+    if (lowerA.includes(lowerSearchTerm) && !lowerB.includes(lowerSearchTerm)) {
+      return -1;
+    }
+    if (lowerB.includes(lowerSearchTerm) && !lowerA.includes(lowerSearchTerm)) {
+      return 1;
+    }
+    return 0;
+  });
 }
 
 /**

--- a/utils/search.ts
+++ b/utils/search.ts
@@ -118,6 +118,9 @@ export function splitOnTerms(content = '', searchTerm = ''): string[] {
   const terms = searchTerm.trim().split(' ');
   const re = new RegExp(`(${terms.join('|')})`, 'gi');
 
+  // Splitting on a RegExp that includes capturing groups will include the
+  // matched terms in the result
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split#splitting_with_a_regexp_to_include_parts_of_the_separator_in_the_result
   return truncate(content.split(re));
 }
 

--- a/utils/search.ts
+++ b/utils/search.ts
@@ -65,8 +65,6 @@ export function searchForTitles({
       return new Set<string>(titles);
     }
 
-    // TODO: Revisit this - why am I adding to result and returning result
-    // instead of returning acc?
     const result = new Set<string>();
 
     titles.forEach(title => {


### PR DESCRIPTION
## What problem does this solve?

The order search results come up in is random, this PR does a rough sort to prioritize titles that contain the search term exactly.

## Details

~This could be further improved by prioritizing searches that match multiple terms in the title first, but I can do that as part of a later PR.~ Donezo, but the implementation could be optimized

## Screenshots

Before | After
-- | --
<img src="https://github.com/runtime-rundown/podcast-site/assets/8823810/abbf81b5-0e86-48ac-8589-eef183237dbb"> | <img src="https://github.com/runtime-rundown/podcast-site/assets/8823810/d265ba34-d72d-4a46-86ab-77584bcf8cca">

