### PR TITLE
Lower revalidation time

### DIFF
--- a/app/episodes/[slug]/page.js
+++ b/app/episodes/[slug]/page.js
@@ -6,7 +6,8 @@ import LineBreak from '../../../components/LineBreak';
 import Hero from '../../../components/Hero';
 import { FEED, getFeed } from '../../../feeds/rss';
 
-export const revalidate = 604800;
+// Revalidate every 24 hours
+export const revalidate = 60 * 60 * 24;
 
 async function EpisodePage({ params: { slug } }) {
   // With `revalidate` this is treated like getStaticProps


### PR DESCRIPTION
We've had some problems with the site not picking up the latest shows from the RSS feed. Let's try lowering the revalidation time to once a day.